### PR TITLE
Allow custom nsesa-editor-an.properties path

### DIFF
--- a/src/main/resources/applicationContext.xml
+++ b/src/main/resources/applicationContext.xml
@@ -25,12 +25,17 @@
 
     <aop:aspectj-autoproxy/>
 
+    <!-- Configure the properties via placeholders. We will first read the properties file on the classpath,
+    which can be overridden via another properties file in the local home directory and finally by setting
+    the java parameter/environment variable NSESA_EDITOR_AN_PROPERTIES to a path
+    such as /any/path/nsesa-editor-an.properties. -->
     <bean id="propertyConfigurer"
           class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer">
         <property name="locations">
             <list>
                 <value>classpath:nsesa-editor-an.properties</value>
                 <value>file:///${user.home}/nsesa-editor-an.properties</value>
+                <value>file://#{ systemProperties['NSESA_EDITOR_AN_PROPERTIES'] }</value>
             </list>
         </property>
         <property name="ignoreUnresolvablePlaceholders" value="false"/>

--- a/src/main/resources/nsesa-editor-an.properties
+++ b/src/main/resources/nsesa-editor-an.properties
@@ -12,8 +12,10 @@
 # See the Licence for the specific language governing permissions and limitations under the Licence.
 #
 
-# default properties file (supposed to be overridden by an external file called nsesa-editor-an.properties)
-# in the /${user.home} directory.
+# Default properties file (supposed to be overridden by an external file called nsesa-editor-an.properties)
+# in the /${user.home} directory or by setting the java parameter/environment variable
+# NSESA_EDITOR_AN_PROPERTIES to a path such as /any/path/nsesa-editor-an.properties.
+
 gwt-log.symbolMaps.editor=
 
 # base url for the services (no slash at the end)

--- a/src/main/resources/spring-servlet.xml
+++ b/src/main/resources/spring-servlet.xml
@@ -28,13 +28,16 @@
     <context:component-scan base-package="org.nsesa.editor, org.nsesa.admin"/>
     <mvc:annotation-driven/>
     <!-- Configure the properties via placeholders. We will first read the properties file on the classpath,
-    which can be overridden via another properties file in the local home directory. -->
+    which can be overridden via another properties file in the local home directory and finally by setting
+    the java parameter/environment variable NSESA_EDITOR_AN_PROPERTIES to a path
+    such as /any/path/nsesa-editor-an.properties. -->
     <bean id="propertyConfigurer"
           class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer">
         <property name="locations">
             <list>
                 <value>classpath:nsesa-editor-an.properties</value>
                 <value>file:///${user.home}/nsesa-editor-an.properties</value>
+                <value>file://#{ systemProperties['NSESA_EDITOR_AN_PROPERTIES'] }</value>
             </list>
         </property>
         <property name="ignoreUnresolvablePlaceholders" value="false"/>


### PR DESCRIPTION
By setting the environment variable `NSESA_EDITOR_AN_PROPERTIES` or java
parameter `-DNSESA_EDITOR_AN_PROPERTIES` to a path such as
`/any/path/nsesa-editor-an.properties` properties can be loaded from
anywhere in the file system. This is useful for production systems.

Loading from `${user.home}/nsesa-editor-an.properties` is still
supported.

---

Edit: hard-coded `file://` which means less typing, less flexibility and no null pointer exceptions when no value was set.
