### PR TITLE
Don't hardcode URL scheme, domain, port in HTML

### DIFF
--- a/web/WEB-INF/decorators/default.jsp
+++ b/web/WEB-INF/decorators/default.jsp
@@ -25,7 +25,7 @@
 
 
     <!-- use as a base URL - makes subsequent URLs much cleaner since we don't need a context path -->
-    <base href="${pageContext.request.scheme}://${pageContext.request.serverName}:${pageContext.request.serverPort}${pageContext.request.contextPath}/"/>
+    <base href="${pageContext.request.contextPath}/"/>
 
     <link rel='stylesheet' href='//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css'>
     <script src="//code.jquery.com/jquery-1.11.0.min.js"></script>

--- a/web/login.jsp
+++ b/web/login.jsp
@@ -27,7 +27,7 @@
     <!-- Bootstrap -->
     <!-- Latest compiled and minified CSS -->
     <!-- use as a base URL - makes subsequent URLs much cleaner since we don't need a context path -->
-    <base href="${pageContext.request.scheme}://${pageContext.request.serverName}:${pageContext.request.serverPort}${pageContext.request.contextPath}/"/>
+    <base href="${pageContext.request.contextPath}/"/>
 
     <link rel='stylesheet' href='css/bootstrap.min.css'>
     <script src="js/jquery-1.11.0.min.js"></script>


### PR DESCRIPTION
Serving hardcoded HTML base URL scheme, domain and port from the server's
point of view to the client breaks when proxying to use publicly facing
settings different from the one configured internally in the webserver.

The context path is still used, and needs to be the same internally as
well as externally.

This enables for example proxied HTTPS support, while allowing export services
to make requests which do not require roundtrips outside of the server.
